### PR TITLE
Table builder rbindlist stephen

### DIFF
--- a/functions/tb.R
+++ b/functions/tb.R
@@ -1,8 +1,15 @@
 library(data.table)
 tb <- function(dt, country = 'England') {
-  rbindlist(list(dt[FTR == 'H',.(p = uniqueN(AwayTeam) * 3), by = 'HomeTeam'],
-                 dt[FTR == 'A',.(p = uniqueN(HomeTeam) * 3), by = 'AwayTeam'],
-                 dt[FTR == 'D',.(p = uniqueN(AwayTeam)), by = 'HomeTeam'],
-                 dt[FTR == 'D',.(p = uniqueN(HomeTeam)), by = 'AwayTeam'])
-            )[,lapply(.SD,sum,na.rm=TRUE),by=HomeTeam][order(p,decreasing=TRUE)]
+  t <- rbindlist(list(dt[FTR == 'H', .(p = uniqueN(AwayTeam) * 3),
+                         by = 'HomeTeam'],
+                      dt[FTR == 'A', .(p = uniqueN(HomeTeam) * 3),
+                         by = 'AwayTeam'],
+                      dt[FTR == 'D', .(p = uniqueN(AwayTeam)),
+                         by = 'HomeTeam'],
+                      dt[FTR == 'D', .(p = uniqueN(HomeTeam)),
+                         by = 'AwayTeam']))[,lapply(.SD,sum,na.rm=TRUE),
+                                            by=HomeTeam]
+  # if(sum(duplicated(t$p)) > 1) {} else {
+  #   t[order(p,decreasing = TRUE)]
+  # }
 }


### PR DESCRIPTION
__What__
first pass at table building w/ `data.table` specific functions

__Why__
Ready to move on to tie based on points, can sort out `plyr` later

__How__
uses `rbindlist` on 4 diff tables, representing the four methods of deriving points from [football-data's](http://football-data.co.uk/) csvs
1) Home Wins
2) Away Wins
3) Home Draws
4) Away Draws

__QA__
Output matches [wikipedia](https://en.wikipedia.org/wiki/2016%E2%80%9317_Premier_League#League_table)

```r
> tb(dt)
# HomeTeam  p
# 1:        Chelsea 93
# 2:      Tottenham 86
# 3:       Man City 78
# 4:      Liverpool 76
# 5:        Arsenal 75
# 6:     Man United 69
# 7:        Everton 61
# 8:    Bournemouth 46
# 9:    Southampton 46
# 10:       West Ham 45
# 11:      West Brom 45
# 12:      Leicester 44
# 13:          Stoke 44
# 14: Crystal Palace 41
# 15:        Swansea 41
# 16:        Burnley 40
# 17:        Watford 40
# 18:           Hull 34
# 19:  Middlesbrough 28
# 20:     Sunderland 24
```