### PR TITLE
remove them damn NAs

### DIFF
--- a/functions/forklift.R
+++ b/functions/forklift.R
@@ -25,5 +25,6 @@ if(as.numeric(first_year) < 2000 && as.numeric(last_year) >= 2010) {
 patron <- paste(country, tier, re, sep = '_')
 temp <- list.files(path = paste0('data/',tolower(country),'/'),
                    pattern= patron)
-lapply(paste0('data/',tolower(country),'/', temp), fread)
+temp <- lapply(paste0('data/',tolower(country),'/', temp), fread)
+lapply(temp, function(x) x[!(is.na(x$FTHG))])
 }


### PR DESCRIPTION
__What__
Remove NAs on the way in

__Why__
2004/2005 has NA rows screwing up totteringham function

__How__
Find NAs and root em out!

__QA__
_Before_
```R
> itty <- forklift(first_year = '2004', last_year = '2004')
> length(unique(itty[[1]]$HomeTeam))
[1] 21
```

_After_
```R
> itty <- forklift(first_year = '2004', last_year = '2004')
> length(unique(itty[[1]]$HomeTeam))
[1] 20
```