### PR TITLE
don't count gd if you don't have to!

### DIFF
--- a/functions/tb/spain_tb.R
+++ b/functions/tb/spain_tb.R
@@ -41,8 +41,10 @@ spain_tb <- function(dt) {
                              temp[FTR == 'D', .(p = uniqueN(HomeTeam)),
                                   by = 'AwayTeam']))[,.(p = sum(p)),
                                                      by = 'HomeTeam']
-      # if(nrow(mini) > 1 & sum(duplicated(mini$p)) > 0) {
-      if(nrow(mini) > 1) {
+      if(nrow(mini) > 1 & sum(duplicated(mini$p)) == 0) {
+        mini <- mini[order(p, decreasing = TRUE)]
+      }
+      else if(nrow(mini) > 1) {
         mini <- merge(mini,rbindlist(list(temp[, .(scored = sum(FTHG)),
                                                by = 'HomeTeam'],
                                           temp[,sum(FTAG),by = 'AwayTeam']))


### PR DESCRIPTION
__What__
Add a check to see if we have to calculate goal difference on the head to head section

__Why__
Avoid unnecessary steps

__How__
An if before the row count step

__QA__
No discrepancies w/ scraped

```r
> sl <- forklift(first_year = '2002', last_year = '2016', country = 'Spain', scraped = TRUE)
> pl <- forklift(country = 'Spain', first_year = '2002', last_year = '2016')
> mapply(scraped_vs_pulled,sl,pl, country = pais, SIMPLIFY = FALSE)
[[1]]
[1] TRUE

[[2]]
[1] TRUE

[[3]]
[1] TRUE

[[4]]
[1] TRUE

[[5]]
[1] TRUE

[[6]]
[1] TRUE

[[7]]
[1] TRUE

[[8]]
[1] TRUE
```